### PR TITLE
fix: syntaxe error in "all" command

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ JAVA = java
 MAVEN = mvn
 
 
-all: install | build | test | lint | fmt 
+all: install build test lint fmt 
 	@echo "All tasks completed"
 
 install: 


### PR DESCRIPTION
## Description
Fix syntaxe error in `makefile`

---
## Related Issue(s)
Closed #17 

---
## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement 
- [ ] Refactor 
- [ ] test 
- [ ] Documentation update

---
## Checklist
- [X] My code follows the style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective (if needed)
- [ ] New and existing unit tests pass locally
- [ ] Documentation updated accordingly 

